### PR TITLE
Add option to print elapsed time for tests

### DIFF
--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -36,7 +36,11 @@ function! s:GetMiscArguments()
     let l:args = l:args . " --gtest_stream_result_to=localhost:2705"
   endif
 
-  let l:args = l:args . " --gtest_print_time=0"
+  if exists('g:gtest#print_time') && g:gtest#print_time
+    let l:args = l:args . " --gtest_print_time=1"
+  else
+    let l:args = l:args . " --gtest_print_time=0"
+  endif
 
   return l:args
 endfunction

--- a/doc/gtest.txt
+++ b/doc/gtest.txt
@@ -32,6 +32,11 @@ Set this to 1 if you want enable failing tests highlight.
 >
   let g:gtest#highlight_failing_tests = 0
 <
+                                                           *g:gtest#print_time*
+Set this to 1 if you want gtest to print the elapsed time of each test.
+>
+  let g:gtest#print_time = 0
+<
 
 COMMANDS *gtest-commands*
 


### PR DESCRIPTION
Printing the elapsed time of each test is disabled by default and there was no way to easily configure it. This adds the option `g:gtest#print_time`.